### PR TITLE
Fix extract_success_test_ids method

### DIFF
--- a/lib/xcode_summary/plugin.rb
+++ b/lib/xcode_summary/plugin.rb
@@ -258,23 +258,14 @@ module Danger
     end
 
     def extract_success_test_ids(xcode_summary)
-      xcode_summary.action_test_plan_summaries.map do |test_plan_summaries|
-        test_plan_summaries.summaries.map do |summary|
-          summary.testable_summaries.map do |test_summary|
-            test_summary.tests.filter_map do |action_test_object|
-              if action_test_object.instance_of? XCResult::ActionTestSummaryGroup
-                action_test_object.subtests.filter_map do |subtest|
-                  @success_test_ids = subtest.subtests.flat_map do |s|
-                    s.subtests.select { |test| test.test_status == 'Success' }.map do |test|
-                      test.identifier.gsub('/', '.')
-                    end
-                  end
-                end
-              end
-            end
-          end
-        end
-      end
+      @success_test_ids = xcode_summary
+                          .action_test_plan_summaries
+                          .flat_map(&:summaries)
+                          .flat_map(&:testable_summaries)
+                          .flat_map(&:all_tests)
+                          .flat_map(&:all_subtests)
+                          .select { |test| test.test_status == 'Success' }
+                          .map { |test| test.identifier.gsub('/', '.') }
     end
 
     def warnings(action)


### PR DESCRIPTION
This PR fixes that the `extract_success_test_ids` method fails for Xcode 16 builds with
> /Users/admin/actions-runner/_work/tr-ios/tr-ios/vendor/bundle/ruby/3.3.0/bundler/gems/danger-xcode_summary-b27c54270704/lib/xcode_summary/plugin.rb:267:in `block (5 levels) in extract_success_test_ids': undefined method `subtests' for an instance of XCResult::ActionTestMetadata (NoMethodError)